### PR TITLE
Add shell formatting to NPM commands

### DIFF
--- a/npm-commands.md
+++ b/npm-commands.md
@@ -1,2 +1,4 @@
+```sh
 npx create-react-app . --template minimal
 npm install three @react-three/fiber @react-three/drei
+```


### PR DESCRIPTION
Hi! I noticed the npm-commands.md file didn't show a line break when rendered. My fix was to put it in code formatting, but a double-space at the end of the first line would work too.